### PR TITLE
Make sure "overlay text" always exists as a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 dist/
 target/
 run_logs/
-overlay text/*
+overlay text/*.txt


### PR DESCRIPTION
The directory not existing causes a crash even with w+. Git can't handle empty directories and needs a stub file.

The directory probably still exists on your local filesystem, which is why you didn't notice.
