### PR TITLE
Support XDG location on Linux

### DIFF
--- a/item_tracker.py
+++ b/item_tracker.py
@@ -650,8 +650,8 @@ class IsaacTracker:
             logfile_location = os.environ[
                                    'USERPROFILE'] + '/Documents/My Games/Binding of Isaac Rebirth/'
         elif platform.system() == "Linux":
-            logfile_location = os.path.expanduser(
-                '~') + '/.local/share/binding of isaac rebirth/'
+            logfile_location = os.getenv('XDG_DATA_HOME',
+                os.path.expanduser('~') + '/.local/share') + '/binding of isaac rebirth/'
         elif platform.system() == "Darwin":
             logfile_location = os.path.expanduser(
                 '~') + '/Library/Application Support/Binding of Isaac Rebirth/'


### PR DESCRIPTION
Reasons for adding this: Rebirth is in a different location on my
system, due to the game following the XDG spec, which puts rebirth data
files into XDG_DATA_HOME/binding\ of\ isaac\ rebirth/ if the variable is
set, otherwise it defaults into ~/.local/share/binding\ of\ isaac\ rebirth/

On this system, I have this set
XDG_DATA_HOME=/home/john/settings/data
which puts the files into ~/settings/data/binding\ of\ isaac\ rebirth/

For users without this environment variable set, it will still behave as it did
beforehand.
