### PR TITLE
Fix conflict in geometry manager for option picker

### DIFF
--- a/option_picker.py
+++ b/option_picker.py
@@ -112,7 +112,6 @@ for index, opt in enumerate(["show_font"]):
     initialvar = StringVar()
     initialvar.set(options.get(opt))
     entries[opt] = ttk.Combobox(root, values=sorted(fonts), textvariable=initialvar, state='readonly')
-    entries[opt].pack()
     entries[opt].grid(row=nextrow, column=1)
     nextrow += 1
 


### PR DESCRIPTION
When running the tracker I couldn't open the option picker because of a conflict in the geometry manager : 

```
Traceback (most recent call last):
  File "option_picker.py", line 115, in <module>
    entries[opt].pack()
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1943, in pack_configure
    + self._options(cnf, kw))
_tkinter.TclError: cannot use geometry manager pack inside . which already has slaves managed by grid

```

It has been introduced by ac6d77456be46bf3efa713ff4198b04b12ea3cf6, do you actually manage to open the option picker on current master ?
Letting the grid manage the layout is sufficient, so the fix should be as simple as removing the "pack".
