### PR TITLE
Sets a default floor if it's undefined.

### DIFF
--- a/src/item_tracker.py
+++ b/src/item_tracker.py
@@ -519,6 +519,9 @@ class IsaacTracker:
                             item_id = "NEW"
                         item_info = self.get_item_info(item_id)
 
+                        # Default current floor to basement 1 if none
+                        if self.current_floor is None:
+                            self.current_floor = Floor("f1", self, False)
                         # If the item IDs are equal, it should say this item already exists
                         temp_item = Item(item_id,self.current_floor,item_info,getting_start_items)
                         if ((current_line_number + self.seek) - self.spawned_coop_baby) < (len(self.collected_items) + 10) \


### PR DESCRIPTION
If we didn't encountered a "Level::Init" by the time we reach the first object,
then default the current floor to b1.

This should fix #56 and Ou_J's similar issue.

Some more details : Ou_J's log is here http://pastebin.com/PR66ehg9, everything looks fine except there is no "Level::Init" for basement 1 !
