### PR TITLE
Book of belial no longer gives guaranteed devil deals

### DIFF
--- a/items.json
+++ b/items.json
@@ -225,7 +225,7 @@
    "034": {
       "name": "The Book of Belial",
       "shown": true,
-      "text": "guarantees deals, x1.5 dmg with blood of the martyr, temporary +2 dmg",
+      "text": "+12.5% deal chance, x1.5 dmg with blood of the martyr, temporary +2 dmg",
       "space": true
    },
    "035": {


### PR DESCRIPTION
Changed to +12.5% deal chance.
