### PR TITLE
Implement __hash__ for Item

### DIFF
--- a/src/game_objects/item.py
+++ b/src/game_objects/item.py
@@ -75,6 +75,9 @@ class Item(object):
             return True
         return other is None or self.id != other.id
 
+    def __hash__(self):
+        return hash(self.id)
+
 # Player stat constants (keys to player_stats and player_stats_display)
 class Stat: # This is a subset of all available ItemProperty's
     DMG         = "dmg"

--- a/src/view_controls/view.py
+++ b/src/view_controls/view.py
@@ -171,6 +171,8 @@ class DrawingTool:
             if self.drawn_items_cache.get(item) is not None:
                 # Grab the item from a cache if we already have one; there is no point creating so many objects
                 new_drawable = self.drawn_items_cache.get(item)
+                # Update the floor as the cached item may be from a previous run
+                new_drawable.item.floor = item.floor
                 new_drawable.x = initial_x
                 new_drawable.y = initial_y
                 new_drawable.is_drawn = False


### PR DESCRIPTION
Fixes #63.
Python uses **hash** method from objects to check if it's in a set.
For Item we can just hash the id since two items are equal if their ids are equal.

For this issue, Guppy's paw was added twice to the set, therefore displaying a
guppy counter of 2 instead of 1.
