### PR TITLE
The tracker displays curses with BLCKCNDL activated

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ You can mouse over items you've picked up to see their stats again, and click on
 ## Known issues
 
 * When using the _Glowing Hourglass_ right after taking any object, this object will remains in the tracker even if the character doesn't have it anymore.
+* When activating an easter egg removing curses (such as `BLCKCNDL`), the tracker will still display curses (such as displaying a '?' over an item), even if they are actually removed in the game.


### PR DESCRIPTION
The game still outputs the curse to the log file when using an easter egg, so for instance we may end up with "BXL" followed by "B2" in the floor layout.
I didn't find any hint about easter egg activation in the log file so I think that's going to be a known issue.

I tried to formulate this correctly in the readme but feel free to change to a better wording/explanation.
