### PR TITLE
Fix reflow issue.

### DIFF
--- a/src/item_tracker.py
+++ b/src/item_tracker.py
@@ -92,10 +92,13 @@ class IsaacTracker(object):
                     drawing_tool.set_window_title(update_notifier, twitch_username)
                 else:
                     drawing_tool.set_window_title(update_notifier, "")
+                # Force view update on change
+                if state != None:
+                    state.modified = True
             if opt.write_to_server and opt.write_to_server != write_to_server:
                 framecount = 0
                 write_to_server = True
-                # Will force writing the correct state, as the parser uses the same
+                # Will force writing the correct state to the server, as the parser uses the same
                 # state during its lifetime
                 if state != None:
                     state.modified = True

--- a/src/view_controls/view.py
+++ b/src/view_controls/view.py
@@ -157,7 +157,7 @@ class DrawingTool(object):
             return
 
         # If items were added, or removed (run restarted) regenerate items
-        if self.state.modified or len(self.drawn_items) < len(self.state.item_list):
+        if self.state.modified:
             self.__reflow()
             # We picked up an item, start the counter
             self.item_picked_up()
@@ -451,6 +451,7 @@ class DrawingTool(object):
     def reset(self):
         self.selected_item_index = None
         self.drawn_items = []
+        self.item_position_index = []
 
     def set_window_title(self, update_notifier, username):
         title = "Rebirth Item Tracker" + update_notifier


### PR DESCRIPTION
When you don't change the state but stop displaying specific items such as health ups,
the tracker would reflow constantly.
We now check for state modification, and force a state update when changing the tournament mode.
Thanks Fisshy ;)
