### PR TITLE
(Attempt to) Implement cross platform options' window positioning

### DIFF
--- a/src/option_picker.py
+++ b/src/option_picker.py
@@ -9,6 +9,7 @@ from options import Options
 import logging
 import urllib2
 import webbrowser
+import platform
 
 class OptionsMenu(object):
     """
@@ -373,8 +374,13 @@ class OptionsMenu(object):
         # we can't use the "screenwidth" and "screenheight" functions because they only give info on the primary display!
         self.root.geometry('+%d+%d' % (x_pos, y_pos))
         self.root.attributes("-alpha", 00)
-        self.root.state("zoomed")
-        self.root.update()
+        if platform.system() == "Windows":
+            self.root.state("zoomed")
+            self.root.update()
+        else:
+            self.root.attributes("-fullscreen", True)
+            # For some reason using 'update' here affects the actual window height we want to get later
+            self.root.update_idletasks()
 
         # our current width and height are now our display's width and height
         screen_width = self.root.winfo_width()
@@ -385,8 +391,12 @@ class OptionsMenu(object):
         origin_y = self.root.winfo_y()
 
         # now we get out of invisible fullscreen mode
-        self.root.state("normal")
         self.root.attributes("-alpha", 0xFF)
+        if platform.system() == "Windows":
+            self.root.state("normal")
+        else:
+            self.root.attributes("-fullscreen", False)
+            self.root.update()
 
         # here's the actual size of the window we're drawing
         window_width = self.root.winfo_width()

--- a/src/view_controls/view.py
+++ b/src/view_controls/view.py
@@ -94,9 +94,10 @@ class DrawingTool(object):
         self.clock.tick(int(Options().framerate_limit))
 
     def save_window_position(self):
-        win_pos = self.win_info.getScreenPosition()
-        Options().x_position = win_pos["left"]
-        Options().y_position = win_pos["top"]
+        if platform.system() == "Windows":
+            win_pos = self.win_info.getScreenPosition()
+            Options().x_position = win_pos["left"]
+            Options().y_position = win_pos["top"]
 
     def handle_events(self):
         """ Handle any pygame event """


### PR DESCRIPTION
The first commit fixes the use of a platform-specific object.
It's interesting to note that the tracker's position is never saved if you're not running windows (not a very annoying issue though).

The second attempts to fix the window/screen size detection on Linux.
The state "zoomed" doesn't exist and causes the tracker to crash.
I think an alternative would be to use the "fullscreen" attribute, which exists on both platforms.

After playing around with the different values and functions from tkinter, I found out using `update` on the window after going fullscreen fucks up the value we get when we switch back.
E.g. : after going fullscreen I correctly get my screen resolution (1920x1080), but when switching back I still get 1920x1080 for the window size. Using `update_idletasks` gives me the correct window size.

Could one please check if that still works as intended under windows ?
