### PR TITLE
Fix 403 errors for browser integrity checks

### DIFF
--- a/src/item_tracker.py
+++ b/src/item_tracker.py
@@ -185,6 +185,7 @@ class IsaacTracker(object):
                         request = urllib2.Request(put_url,
                                                   data=json_string)
                         request.add_header('Content-Type', 'application/json')
+                        request.add_header('User-Agent', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11')
                         request.get_method = lambda: 'PUT'
                         try:
                             result = opener.open(request)


### PR DESCRIPTION
Many load balancers and reverse proxies (e.g. Cloudflare) use browser integrity checks, which do not allow regular user agents through. This masks the request as coming from a browser.